### PR TITLE
Fix duplicate safe.directory entries in gitconfig

### DIFF
--- a/biobricks/brick.py
+++ b/biobricks/brick.py
@@ -33,7 +33,7 @@ class Brick:
         
         is_safe = check_safe_git_repo(bdir)
         if not is_safe:
-            subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', bdir])
+            subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', str(bdir)])
             
         commit = gsys("git rev-parse HEAD").decode().strip()
         remote = gsys("git config --get remote.origin.url").decode().strip()
@@ -149,10 +149,10 @@ class Brick:
         """Get the assets for this brick."""
         brick_dir = self.path()
         
-        is_safe = check_safe_git_repo(self.path())
-        
+        is_safe = check_safe_git_repo(brick_dir)
+
         if not is_safe:
-            subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', brick_dir])
+            subprocess.check_call(['git', 'config', '--global', '--add', 'safe.directory', str(brick_dir)])
         
         if not brick_dir.exists():
             raise Exception(f"No path '{brick_dir}'. Try `biobricks install {self.url()}`")

--- a/biobricks/checks.py
+++ b/biobricks/checks.py
@@ -11,7 +11,9 @@ def check_safe_git_repo(git_repo_path):
     except subprocess.CalledProcessError as e:
         raw_safe_dirs = ""
     safe_dirs = [line.split(' ')[1] for line in raw_safe_dirs.split('\n') if line.strip() != '']
-    return git_repo_path in safe_dirs
+    # Normalize path to string for comparison
+    normalized_path = str(Path(git_repo_path).resolve())
+    return normalized_path in safe_dirs or str(git_repo_path) in safe_dirs
         
 def check_url_available(url):
     try:


### PR DESCRIPTION
## Summary
- Fixed `check_safe_git_repo()` comparing Path objects against strings, which always returned False
- This caused the same directories to be added repeatedly to `~/.gitconfig`, bloating it (1200+ duplicate entries)
- Also leads to lock file conflicts when multiple processes try to modify the config simultaneously

## Changes
- Normalize path to string before comparison in `check_safe_git_repo()`
- Ensure `brick.py` passes string paths to `git config --add`

## Test plan
- [ ] Run biobricks operations multiple times and verify no new duplicates are added to `.gitconfig`
- [ ] Verify existing safe.directory entries are properly detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)